### PR TITLE
Publish to PyPI via Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,10 +1,7 @@
-# This workflow will upload a Python Package using Twine when a release is created
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
-
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
+# Build and publish the package to PyPI when a GitHub release is published.
+# Uses PyPI Trusted Publishing (OIDC) — no API token/secret required.
+# See: https://docs.astral.sh/uv/guides/integration/github/#publishing
+#      https://docs.pypi.org/trusted-publishers/
 
 name: Upload Python Package
 
@@ -14,8 +11,12 @@ on:
 
 jobs:
   deploy:
-
     runs-on: ubuntu-latest
+    permissions:
+      # Required for Trusted Publishing: lets the job mint a short-lived OIDC
+      # token that PyPI exchanges for an upload token. No stored secret.
+      id-token: write
+      contents: read
 
     steps:
     - uses: actions/checkout@v5
@@ -23,10 +24,6 @@ jobs:
       uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
     - name: Build package
       run: uv build
-    # NOTE: Trusted Publishing (OIDC) is the recommended follow-up; it removes
-    # the need for the PYPI_API_TOKEN secret. Keeping the token flow for now.
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+      # uv auto-detects the GitHub Actions OIDC credentials (trusted publishing).
+      run: uv publish


### PR DESCRIPTION
Replaces the long-lived `PYPI_API_TOKEN` secret with PyPI **Trusted Publishing (OIDC)**. Follow-up to the v2.1.0 revival — removes the 5-year-old account-scoped token as a credential to leak, rotate, or expire.

## What changed
- `python-publish.yml` now runs `uv publish` with `permissions: id-token: write`; uv auto-detects the GitHub Actions OIDC credentials.
- Dropped the `pypa/gh-action-pypi-publish` step and the `secrets.PYPI_API_TOKEN` reference.

## Required before the next release (maintainer, one-time on PyPI)
1. **Add the Trusted Publisher:** https://pypi.org/manage/project/sqlalchemyseed/settings/publishing/
   - Owner: `jedymatt` · Repository: `sqlalchemyseed` · Workflow: `python-publish.yml` · Environment: *(blank)*
2. **Revoke** the old 2021 account-scoped API token: https://pypi.org/manage/account/token/
3. Delete the now-unused `PYPI_API_TOKEN` GitHub secret (can be done via `gh secret delete`).

Until step 1 is done, a release run would fail at the publish step — no data risk, just a failed upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)